### PR TITLE
Quick fix for automatic resizing on touch initiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ var handleTouchyPinch = function (e, $target, data) {
 $('#my_div').bind('touchy-pinch', handleTouchyPinch);
 ```
 
+If you're facing unexpected resizing on first touch, use this method to bind Touchy event :
+
+```javascript
+let initScale = 0;
+var handleTouchyPinch = function (e, $target, data) {
+    if(initScale !== 0)
+      initScale+=data.scale - data.previousScale;
+    else
+      initScale = data.scale;
+    $target.css({'webkitTransform':'scale(' + initScale + ',' + initScale + ')'});
+};
+$('#my_div').bind('touchy-pinch', handleTouchyPinch);
+```
+
 ## Touchy Events
 
 Touchy currently enables the use of the following events:


### PR DESCRIPTION
On every touch initiation it takes data.scale as 1 due to which the image size unexpectedly changes if we aleady have some css transform values set up. 
The fix would be: For the very first time, transform with data.scale. And in rest of the cases set the scaling relative to previous scale values.